### PR TITLE
Update GRIB2SurfaceLocalTable.csv

### DIFF
--- a/grib/grib2/GRIB2SurfaceLocalTable.csv
+++ b/grib/grib2/GRIB2SurfaceLocalTable.csv
@@ -1,4 +1,4 @@
 Code figure,Parameter,Unit
-192,Level of wet-bulb potential temperature 0 °C isotherm,
+192,Level of wet-bulb temperature 0 °C isotherm,
 193,Convective cloud layer bottom level,
 194,Convective cloud layer top level,


### PR DESCRIPTION
The word 'potential' removed from the description of this surface type.